### PR TITLE
Upgrade artesaos/seotools for L8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-json": "*",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",
         "illuminate/database": "^6.0 || ^7.0 || ^8.0",
-        "artesaos/seotools": "^0.18.0"
+        "artesaos/seotools": "^0.19.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Upgrade artesaos/seotools to v.19.0 to work with L8

## Motivation and context

Laravel 8 upgrade isn't working with v.18

